### PR TITLE
[Server] edit : 일반 회원가입 후 이메인 미인증 상태에서 카카오톡 로그인을 진행하면 인증여부가 참이 되도록 수정

### DIFF
--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -93,8 +93,8 @@ module.exports = {
                       : 'http://localhost:3000'
                   const from = `AtoZ sports <atozsports@api.atozsports.link>`
                   const emailOptions = {
-                    from: from, //test중 AWS SES 등록 도메인 테스트를 기다리는 중이라 임시설정
-                    to: userData.email, //test중 원래는 userData.email이 맞다
+                    from: from,
+                    to: userData.email,
                     subject: `${userData.nickname}님 ! AtoZ sports 임시 비밀번호 발급입니다.`,
                     html: `
                     <div>
@@ -141,7 +141,6 @@ module.exports = {
               let updatedUser = await User.findOne({
                 where: { email: userKakaoEmail }
               })
-              console.log('여기여기',updatedUser.dataValues)
               let userData = updatedUser.dataValues
               delete userData.password
               const accessToken = generateAccessToken(userData)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✓] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/controller-4 -> dev

### 변경 사항
일반 회원가입 후 메일인증이 완료되지 않은 상태에서 사용자가 회원가입시 입력한 이메일과 동일한 이메일로 카카오톡 계정을 가지고 있다면
카카오톡 로그인시 회원 데이터의 인증여부가 참으로 바뀌면서 로그인이 되도록 구현

### 테스트 결과
데이터베이스에서 사용자의 인증여부 값이 참으로 바뀌는 것을 확인했고 리덕스의 상태값에서도 사용자의 인증여부 값이 참으로 저장된 것을 확인했다